### PR TITLE
add default props, fix header

### DIFF
--- a/RouterComponent.js
+++ b/RouterComponent.js
@@ -68,24 +68,27 @@ class Router extends PureComponent {
     return route;
   }
 
-  renderHeader(sceneProps) {
-    const { header: HeaderComponent } = this.props;
-    const { route: { key } } = sceneProps.scene;
-    const routeProps = this.getRoute(key);
+  getRouteParams(route) {
+    const { defaultParams = {} } = this.getRoute(route.key);
+    const { params = {} } = route;
+    return { ...defaultParams, ...params };
+  }
 
+  renderHeader({ scene: { route } }) {
+    const { header: HeaderComponent } = this.props;
     return HeaderComponent ? <HeaderComponent
-      {...sceneProps}
-      {...routeProps}
+      key={route.key}
+      params={this.getRouteParams(route)}
       onNavigateBack={this.handleBackAction}
     /> : null;
   }
 
-  renderScene({ scene }) {
-    const { key, params } = scene.route;
-    const { component: RouteComponent } = this.getRoute(key);
-
+  renderScene({ scene: { route } }) {
+    const { key } = route;
+    const { component: RouteComponent }  = this.getRoute(key);
     return <RouteComponent
-      params={params}
+      key={key}
+      params={this.getRouteParams(route)}
     />;
   }
 


### PR DESCRIPTION
Added default params for in router definition.
```javascript
routes: [
    {
      key: 'about',
      defaultParams: {
        name: 'vasia',
      },
      component: InfoScreen,
    },
   ...
   {
      key: 'first-item',
      component: connect(null,
        (dispatch) => ({
          nextButtonHandler: (id) => dispatch(actionCreators.push({ key: 'about', params: { name: 'Petia' } })),
      }))(ItemScreen),
    },
   ...
   {
      key: 'second-item',
      component: connect(null,
        (dispatch) => ({
          nextButtonHandler: (id) => dispatch(actionCreators.push({ key: 'about' })),
      }))(ItemScreen),
   }
  ],
```

Also added passing of the same props to header.